### PR TITLE
Use dedicated native GitHub OAuth credentials for the native exchange

### DIFF
--- a/src/lib/server/nativeAuth.server.ts
+++ b/src/lib/server/nativeAuth.server.ts
@@ -151,8 +151,12 @@ export async function exchangeGithubCode(input: {
   code: string;
   redirectUri: string;
 }): Promise<VerifiedProfile> {
-  const clientId = env.GITHUB_ID;
-  const clientSecret = env.GITHUB_SECRET;
+  // A native app needs its own GitHub OAuth App (a GitHub app allows only one
+  // set of callback URLs, and the native custom-scheme callback differs from the
+  // web Auth.js callback). Use its dedicated credentials, falling back to the web
+  // app's if a separate one hasn't been set up.
+  const clientId = env.GITHUB_NATIVE_ID ?? env.GITHUB_ID;
+  const clientSecret = env.GITHUB_NATIVE_SECRET ?? env.GITHUB_SECRET;
   if (!clientId || !clientSecret) throw new Error("GITHUB client is not configured");
 
   const tokenRes = await fetch("https://github.com/login/oauth/access_token", {


### PR DESCRIPTION
The native app requires its own GitHub OAuth App (a GitHub app allows one callback set, and the native custom-scheme callback differs from the web Auth.js callback), so it has a different client id AND secret. The native code exchange now uses GITHUB_NATIVE_ID / GITHUB_NATIVE_SECRET, falling back to the web GITHUB_ID / GITHUB_SECRET if a separate app hasn't been configured.